### PR TITLE
Try mkdir before workdir

### DIFF
--- a/packages/cubejs-docker/latest.Dockerfile
+++ b/packages/cubejs-docker/latest.Dockerfile
@@ -47,6 +47,8 @@ ENV PYTHONUNBUFFERED=1
 RUN ln -s /cube/node_modules/.bin/cubejs /usr/local/bin/cubejs
 RUN ln -s /cube/node_modules/.bin/cubestore-dev /usr/local/bin/cubestore-dev
 
+RUN mkdir -p /cube/conf
+
 WORKDIR /cube/conf
 
 EXPOSE 4000


### PR DESCRIPTION
Cloud build crashing with `error building image: error building stage: failed to execute command: creating workdir /cube/conf: mkdir /cube: file exists`