### PR TITLE
feat(compiler): allow DDL key

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -1033,6 +1033,7 @@ declare module '@cubejs-client/core' {
     public?: boolean;
     meta?: any;
     materialization?: 'view' | 'table' | 'incremental' | null;
+    ddl?: string;
   };
 
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
@@ -51,6 +51,7 @@ export class CubeToMetaTransformer {
         isVisible: isCubeVisible,
         public: isCubeVisible,
         materialization: cube.materialization,
+        ddl: cube.ddl,
         description: cube.description,
         connectedComponent: this.joinGraph.connectedComponents()[cube.name],
         meta: cube.meta,

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -767,6 +767,7 @@ const baseSchema = {
   shown: Joi.boolean().strict(),
   public: Joi.boolean().strict(),
   materialization: Joi.string().valid("view", "table", "incremental").allow(null),
+  ddl: Joi.string(),
   meta: Joi.any(),
   joins: Joi.object().pattern(identifierRegex, Joi.object().keys({
     sql: Joi.func().required(),

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -194,6 +194,27 @@ describe('Yaml Schema Testing', () => {
     });
   });
 
+  describe('ddl', () => {
+    it('can be defined', async () => {
+      const { compiler } = prepareYamlCompiler(`
+        cubes:
+          - name: Products
+            sqlTable: bronze.orders
+            materialization: table
+            ddl: |-
+              CREATE OR REPLACE TABLE bronze.orders AS (
+                SELECT *
+                FROM stripe.orders
+              )
+            dimensions:
+              - name: Title
+                sql: name
+                type: string
+        `)
+      await compiler.compile();
+    })
+  });
+
   describe('Escaping and quoting', () => {
     it('escapes backticks', async () => {
       const { compiler } = prepareYamlCompiler(


### PR DESCRIPTION
The `ddl` key will be used to separately define the CTAS or view definition and allow Cube to use the `sqlTable` key for actually fetching the data. This helps us avoid the need to alter Cube's internal execution engine.
