### PR TITLE
feat(compiler): allow config key

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -1032,7 +1032,10 @@ declare module '@cubejs-client/core' {
     isVisible?: boolean;
     public?: boolean;
     meta?: any;
+    config?: any;
+    /** @deprecated */
     materialization?: 'view' | 'table' | 'incremental' | null;
+    /** @deprecated */
     ddl?: string;
   };
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
@@ -50,10 +50,13 @@ export class CubeToMetaTransformer {
         title: cubeTitle,
         isVisible: isCubeVisible,
         public: isCubeVisible,
+        /** @deprecated */
         materialization: cube.materialization,
+        /** @deprecated */
         ddl: cube.ddl,
         description: cube.description,
         connectedComponent: this.joinGraph.connectedComponents()[cube.name],
+        config: cube.config,
         meta: cube.meta,
         measures: R.compose(
           R.map((nameToMetric) => ({

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -766,8 +766,11 @@ const baseSchema = {
   rewriteQueries: Joi.boolean().strict(),
   shown: Joi.boolean().strict(),
   public: Joi.boolean().strict(),
+  // TODO: Deprecate and remove, please use public
   materialization: Joi.string().valid("view", "table", "incremental").allow(null),
+  // TODO: Deprecate and remove, please use public
   ddl: Joi.string(),
+  config: Joi.any(),
   meta: Joi.any(),
   joins: Joi.object().pattern(identifierRegex, Joi.object().keys({
     sql: Joi.func().required(),

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -190,7 +190,14 @@ export class YamlCompiler {
       return t.booleanLiteral(obj);
     } else if (typeof obj === 'number') {
       return t.numericLiteral(obj);
-    } else if (obj === null && (propertyPath.includes('meta') || propertyPath.includes('materialization'))) {
+    } else if (
+      obj === null
+      && (
+        propertyPath.includes('meta')
+        || propertyPath.includes('materialization')
+        || propertyPath.includes('config')
+      )
+    ) {
       return t.nullLiteral();
     }
 

--- a/packages/cubejs-schema-compiler/test/unit/__snapshots__/views.test.ts.snap
+++ b/packages/cubejs-schema-compiler/test/unit/__snapshots__/views.test.ts.snap
@@ -43,6 +43,7 @@ Object {
   "folders": Array [],
   "hierarchies": Array [],
   "isVisible": true,
+  "materialization": undefined,
   "measures": Array [
     Object {
       "aggType": "number",
@@ -122,6 +123,7 @@ Object {
   "folders": Array [],
   "hierarchies": Array [],
   "isVisible": true,
+  "materialization": undefined,
   "measures": Array [
     Object {
       "aggType": "number",
@@ -235,6 +237,7 @@ Object {
   "folders": Array [],
   "hierarchies": Array [],
   "isVisible": true,
+  "materialization": undefined,
   "measures": Array [
     Object {
       "aggType": "number",
@@ -314,6 +317,7 @@ Object {
   "folders": Array [],
   "hierarchies": Array [],
   "isVisible": true,
+  "materialization": undefined,
   "measures": Array [
     Object {
       "aggType": "number",

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -411,6 +411,36 @@ describe('Yaml Schema Testing', () => {
       `
     );
 
+  it('accepts extended config', async () => {
+    const { compiler } = prepareYamlCompiler(
+      `
+      cubes:
+      - name: Users
+        sql: SELECT * FROM e2e.users
+        config:
+          scalars:
+            example_string: "foo"
+            example_integer: 1
+            example_float: 1.0
+            example_boolean: true
+            example_null: null
+          sequence:
+            - 1
+            - 2
+            - 3
+          mixed_sequence:
+            - 1
+            - "foo"
+            - 3
+        dimensions:
+          - name: id
+            sql: id
+            type: number
+            primaryKey: true
+      `
+    );
+
+
     await compiler.compile();
   });
 


### PR DESCRIPTION
Deprecation of `materialization` and `ddl` keys in favor of adding a new arbitrary object key `config` that can house any and all additional keys needed for modeling/transformation.

Main reason behind this is it is cumbersome to add support for each key individually and to keep up with enabled support for each customer's cube version. Using one key where we can put whatever arbitrary values in allows us to automatically roll out support for a new key value by just updating the Pydantic model(s) in PyBE.

This should be the last update I need to make to actual Cube for this work moving forward.
