### PR TITLE
chore(compiler): remove deprecated keys

### DIFF
--- a/packages/cubejs-client-core/index.d.ts
+++ b/packages/cubejs-client-core/index.d.ts
@@ -1033,10 +1033,6 @@ declare module '@cubejs-client/core' {
     public?: boolean;
     meta?: any;
     config?: any;
-    /** @deprecated */
-    materialization?: 'view' | 'table' | 'incremental' | null;
-    /** @deprecated */
-    ddl?: string;
   };
 
 

--- a/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeToMetaTransformer.js
@@ -50,10 +50,6 @@ export class CubeToMetaTransformer {
         title: cubeTitle,
         isVisible: isCubeVisible,
         public: isCubeVisible,
-        /** @deprecated */
-        materialization: cube.materialization,
-        /** @deprecated */
-        ddl: cube.ddl,
         description: cube.description,
         connectedComponent: this.joinGraph.connectedComponents()[cube.name],
         config: cube.config,

--- a/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/CubeValidator.ts
@@ -766,10 +766,6 @@ const baseSchema = {
   rewriteQueries: Joi.boolean().strict(),
   shown: Joi.boolean().strict(),
   public: Joi.boolean().strict(),
-  // TODO: Deprecate and remove, please use public
-  materialization: Joi.string().valid("view", "table", "incremental").allow(null),
-  // TODO: Deprecate and remove, please use public
-  ddl: Joi.string(),
   config: Joi.any(),
   meta: Joi.any(),
   joins: Joi.object().pattern(identifierRegex, Joi.object().keys({

--- a/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
+++ b/packages/cubejs-schema-compiler/src/compiler/YamlCompiler.ts
@@ -190,14 +190,7 @@ export class YamlCompiler {
       return t.booleanLiteral(obj);
     } else if (typeof obj === 'number') {
       return t.numericLiteral(obj);
-    } else if (
-      obj === null
-      && (
-        propertyPath.includes('meta')
-        || propertyPath.includes('materialization')
-        || propertyPath.includes('config')
-      )
-    ) {
+    } else if (obj === null && (propertyPath.includes('meta') || propertyPath.includes('config'))) {
       return t.nullLiteral();
     }
 

--- a/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
+++ b/packages/cubejs-schema-compiler/test/unit/yaml-schema.test.ts
@@ -154,67 +154,6 @@ describe('Yaml Schema Testing', () => {
     }
   });
 
-  describe('Materializations', () => {
-    const template = (materialization: string) => {
-      return `
-      cubes:
-        - name: Products
-          sql: "select * from tbl"
-          materialization: ${materialization}
-          dimensions:
-            - name: Title
-              sql: name
-              type: string
-        `
-    }
-    it('can be table', async () => {
-      const { compiler } = prepareYamlCompiler(template('table'));
-      await compiler.compile();
-    });
-    it('can be view', async () => {
-      const { compiler } = prepareYamlCompiler(template('view'));
-      await compiler.compile();
-    });
-    it('can be incremental', async () => {
-      const { compiler } = prepareYamlCompiler(template('incremental'));
-      await compiler.compile();
-    });
-    it('can be null', async () => {
-      const { compiler } = prepareYamlCompiler(template('null'));
-      await compiler.compile();
-    });
-    it('cannot be anything else', async () => {
-      const { compiler } = prepareYamlCompiler(template('foo'));
-      try {
-        await compiler.compile();
-        throw new Error("`foo` should not be allowed as a materialization value");
-      } catch (e: any) {
-        expect(e.message).toContain('must be one of [view, table, incremental, null]');
-      }
-    });
-  });
-
-  describe('ddl', () => {
-    it('can be defined', async () => {
-      const { compiler } = prepareYamlCompiler(`
-        cubes:
-          - name: Products
-            sqlTable: bronze.orders
-            materialization: table
-            ddl: |-
-              CREATE OR REPLACE TABLE bronze.orders AS (
-                SELECT *
-                FROM stripe.orders
-              )
-            dimensions:
-              - name: Title
-                sql: name
-                type: string
-        `)
-      await compiler.compile();
-    })
-  });
-
   describe('Escaping and quoting', () => {
     it('escapes backticks', async () => {
       const { compiler } = prepareYamlCompiler(


### PR DESCRIPTION
Removes support for `ddl` and `materialization` keys
